### PR TITLE
🧩 Add addattribute function

### DIFF
--- a/__spec__/addattribute.spec.js
+++ b/__spec__/addattribute.spec.js
@@ -1,0 +1,146 @@
+/* eslint-env mocha */
+const { expect, assert } = require('chai')
+
+const nunjucks = require('nunjucks')
+
+const { addattribute } = require('../index')
+
+const stubs = {
+  string: {
+    given: 'This is a string',
+    expected: '<span hreflang="en-gb">This is a string</span>',
+  },
+  element: {
+    given: nunjucks.runtime.markSafe('<a href="https://example.com">This is a link</a>'),
+    expected: '<a href="https://example.com" id="added-id">This is a link</a>',
+  },
+  addClass: {
+    given: nunjucks.runtime.markSafe('<p class="existing-class">This is a paragraph</p>'),
+    expected: '<p class="existing-class added-class">This is a paragraph</p>',
+  },
+  noContent: {
+    given: nunjucks.runtime.markSafe('<p>This is a paragraph</p>'),
+    expected: '<p data-test-property="true">This is a paragraph</p>',
+  },
+}
+
+describe('the `addattribute`', function () {
+  describe('function', function () {
+    it('should return a `span` when given a string', function () {
+      const { val } = addattribute({
+        element: stubs.string.given,
+        attribute: 'hreflang',
+        content: 'en-gb',
+      })
+      expect(val).to.equal(stubs.string.expected)
+    })
+
+    it('should return the element with the extra attribute', function () {
+      const { val } = addattribute({
+        element: stubs.element.given,
+        attribute: 'id',
+        content: 'added-id',
+      })
+      expect(val).to.equal(stubs.element.expected)
+    })
+
+    it('should add to existing classes', function () {
+      const { val } = addattribute({
+        element: stubs.addClass.given,
+        attribute: 'class',
+        content: 'added-class',
+      })
+      expect(val).to.equal(stubs.addClass.expected)
+    })
+
+    it('defaults to true when no attribute content present', function () {
+      const { val } = addattribute({
+        element: stubs.noContent.given,
+        attribute: 'data-test-property',
+      })
+      expect(val).to.equal(stubs.noContent.expected)
+    })
+
+    it('should fail when no attribute given', function () {
+      assert.throws(
+        function () {
+          addattribute({
+            element: stubs.addClass.given,
+          })
+        },
+        Error,
+        'No attribute parameter given.',
+      )
+    })
+  })
+
+  describe('filter', function () {
+    it('should return a `span` with a class when given a string', function () {
+      const env = new nunjucks.Environment()
+
+      env.addFilter('addclass', (element, classname) => {
+        return addattribute({ element, attribute: 'class', content: classname })
+      })
+
+      const test = env.renderString(`
+        <!DOCTYPE html>
+        <html>
+          <head>
+            <meta charset="utf-8">
+          </head>
+          <body>
+            {{ 'example' | addclass('added-class') }}
+          </body>
+        </html>
+        `)
+
+      const expected = `
+        <!DOCTYPE html>
+        <html>
+          <head>
+            <meta charset="utf-8">
+          </head>
+          <body>
+            <span class="added-class">example</span>
+          </body>
+        </html>
+        `
+
+      expect(test).to.equal(expected)
+    })
+
+    it('can be chained multiple times', function () {
+      const env = new nunjucks.Environment()
+
+      env.addFilter('addclass', (element, classname) => {
+        return addattribute({ element, attribute: 'class', content: classname })
+      })
+
+      const test = env.renderString(`
+        <!DOCTYPE html>
+        <html>
+          <head>
+            <meta charset="utf-8">
+          </head>
+          <body>
+            {{ 'example' | addclass('added-class') | addclass('more-added-class even-more-class') | addclass('classier') }}
+          </body>
+        </html>
+        `)
+
+      const expected = `
+        <!DOCTYPE html>
+        <html>
+          <head>
+            <meta charset="utf-8">
+          </head>
+          <body>
+            <span class="added-class more-added-class even-more-class classier">example</span>
+          </body>
+        </html>
+        `
+
+      expect(test).to.equal(expected)
+    })
+  })
+})

--- a/filters/addattribute.d.ts
+++ b/filters/addattribute.d.ts
@@ -1,0 +1,8 @@
+export = addattribute;
+/**
+ * @param  {string | Object} element - text or Nunjucks marksafe object
+ * @param  {string} attribute - attribute to be added to element
+ * @param {string | boolean} content - attribute content to be added
+ * @return  {Object} A Nunjucks object that is marked as safe.
+ */
+declare function addattribute({ element, attribute, content, }: string | any): any;

--- a/filters/addattribute.js
+++ b/filters/addattribute.js
@@ -1,0 +1,38 @@
+const { load, html } = require('cheerio')
+const { runtime: { markSafe } } = require('nunjucks')
+
+/**
+ * @param  {string | Object} element - text or Nunjucks marksafe object
+ * @param  {string} attribute - attribute to be added to element
+ * @param {string | boolean} content - attribute content to be added
+ * @return  {Object} A Nunjucks object that is marked as safe.
+ */
+const addattribute = ({
+  element,
+  attribute,
+  content = true,
+}) => {
+  if (!element) throw new Error('No element parameter given.')
+  if (!attribute) throw new Error('No attribute parameter given.')
+
+  // If the element is just a string we need to wrap it in a span so we actually
+  // add an attribute to something.
+  const wrappedElement = typeof element === 'string'
+    ? `<span>${element}</span>`
+    : element.val
+
+  const $ = load(
+    wrappedElement,
+    null,
+    false, // `false` to stop this being wrapped in `html` and `body` elements.
+  )
+
+  const elementWithAttribute = $(':root')
+    .attr(attribute, (_i, val) => {
+      return [val, content].filter(x => !!x).join(' ')
+    })
+
+  return markSafe(html(elementWithAttribute))
+}
+
+module.exports = addattribute

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,7 @@
-export const cssmin: typeof import("./filters/cssmin");
-export const debug: typeof import("./filters/debug");
-export const humandate: typeof import("./filters/humandate");
-export const isodate: typeof import("./filters/isodate");
-export const markdownify: any;
+import addattribute = require("./filters/addattribute");
+import cssmin = require("./filters/cssmin");
+import debug = require("./filters/debug");
+import humandate = require("./filters/humandate");
+import isodate = require("./filters/isodate");
+import markdownify = require("./filters/markdownify");
+export { addattribute, cssmin, debug, humandate, isodate, markdownify };

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+const addattribute = require('./filters/addattribute')
 const cssmin = require('./filters/cssmin')
 const debug = require('./filters/debug')
 const humandate = require('./filters/humandate')
@@ -5,6 +6,7 @@ const isodate = require('./filters/isodate')
 const markdownify = require('./filters/markdownify')
 
 module.exports = {
+  addattribute,
   cssmin,
   debug,
   humandate,

--- a/package-lock.json
+++ b/package-lock.json
@@ -111,8 +111,7 @@
     "a-sync-waterfall": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/a-sync-waterfall/-/a-sync-waterfall-1.0.1.tgz",
-      "integrity": "sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA==",
-      "dev": true
+      "integrity": "sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA=="
     },
     "acorn": {
       "version": "7.4.1",
@@ -202,8 +201,7 @@
     "asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
-      "dev": true
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
     },
     "assertion-error": {
       "version": "1.1.0",
@@ -228,6 +226,11 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
       "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
       "dev": true
+    },
+    "boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -337,6 +340,32 @@
       "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
     },
+    "cheerio": {
+      "version": "1.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.5.tgz",
+      "integrity": "sha512-yoqps/VCaZgN4pfXtenwHROTp8NG6/Hlt4Jpz2FEP0ZJQ+ZUkVDd0hAPDNKhj3nakpfPt/CNs57yEtxD1bXQiw==",
+      "requires": {
+        "cheerio-select-tmp": "^0.1.0",
+        "dom-serializer": "~1.2.0",
+        "domhandler": "^4.0.0",
+        "entities": "~2.1.0",
+        "htmlparser2": "^6.0.0",
+        "parse5": "^6.0.0",
+        "parse5-htmlparser2-tree-adapter": "^6.0.0"
+      }
+    },
+    "cheerio-select-tmp": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/cheerio-select-tmp/-/cheerio-select-tmp-0.1.1.tgz",
+      "integrity": "sha512-YYs5JvbpU19VYJyj+F7oYrIE2BOll1/hRU7rEy/5+v9BzkSo3bK81iAeeQEMI92vRIxz677m72UmJUiVwwgjfQ==",
+      "requires": {
+        "css-select": "^3.1.2",
+        "css-what": "^4.0.0",
+        "domelementtype": "^2.1.0",
+        "domhandler": "^4.0.0",
+        "domutils": "^2.4.4"
+      }
+    },
     "clean-css": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.1.0.tgz",
@@ -393,8 +422,7 @@
     "commander": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
-      "dev": true
+      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -418,6 +446,23 @@
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
       }
+    },
+    "css-select": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-3.1.2.tgz",
+      "integrity": "sha512-qmss1EihSuBNWNNhHjxzxSfJoFBM/lERB/Q4EnsJQQC62R2evJDW481091oAdOr9uh46/0n4nrg0It5cAnj1RA==",
+      "requires": {
+        "boolbase": "^1.0.0",
+        "css-what": "^4.0.0",
+        "domhandler": "^4.0.0",
+        "domutils": "^2.4.3",
+        "nth-check": "^2.0.0"
+      }
+    },
+    "css-what": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-4.0.0.tgz",
+      "integrity": "sha512-teijzG7kwYfNVsUh2H/YN62xW3KK9YhXEgSlbxMlcyjPNvdKJqFx5lrwlJgoFP1ZHlB89iGDlo/JyshKeRhv5A=="
     },
     "debug": {
       "version": "4.3.1",
@@ -471,6 +516,39 @@
       "dev": true,
       "requires": {
         "esutils": "^2.0.2"
+      }
+    },
+    "dom-serializer": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.2.0.tgz",
+      "integrity": "sha512-n6kZFH/KlCrqs/1GHMOd5i2fd/beQHuehKdWvNNffbGHTr/almdhuVvTVFb3V7fglz+nC50fFusu3lY33h12pA==",
+      "requires": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.0.0",
+        "entities": "^2.0.0"
+      }
+    },
+    "domelementtype": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.1.0.tgz",
+      "integrity": "sha512-LsTgx/L5VpD+Q8lmsXSHW2WpA+eBlZ9HPf3erD1IoPF00/3JKHZ3BknUVA2QGDNu69ZNmyFmCWBSO45XjYKC5w=="
+    },
+    "domhandler": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.0.0.tgz",
+      "integrity": "sha512-KPTbnGQ1JeEMQyO1iYXoagsI6so/C96HZiFyByU3T6iAzpXn8EGEvct6unm1ZGoed8ByO2oirxgwxBmqKF9haA==",
+      "requires": {
+        "domelementtype": "^2.1.0"
+      }
+    },
+    "domutils": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.4.4.tgz",
+      "integrity": "sha512-jBC0vOsECI4OMdD0GC9mGn7NXPLb+Qt6KW1YDQzeQYRUFKmNG8lh7mO5HiELfr+lLQE7loDVI4QcAxV80HS+RA==",
+      "requires": {
+        "dom-serializer": "^1.0.1",
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.0.0"
       }
     },
     "emoji-regex": {
@@ -1017,6 +1095,17 @@
       "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
       "dev": true
     },
+    "htmlparser2": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.0.0.tgz",
+      "integrity": "sha512-numTQtDZMoh78zJpaNdJ9MXb2cv5G3jwUoe3dMQODubZvLoGvTE/Ofp6sHvH8OGKcN/8A47pGLi/k58xHP/Tfw==",
+      "requires": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.0.0",
+        "domutils": "^2.4.4",
+        "entities": "^2.0.0"
+      }
+    },
     "ignore": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
@@ -1541,11 +1630,18 @@
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
     },
+    "nth-check": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.0.tgz",
+      "integrity": "sha512-i4sc/Kj8htBrAiH1viZ0TgU8Y5XqCaV/FziYK6TBczxmeKm3AEFWqqF3195yKudrarqy7Zu80Ra5dobFjn9X/Q==",
+      "requires": {
+        "boolbase": "^1.0.0"
+      }
+    },
     "nunjucks": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-3.2.3.tgz",
       "integrity": "sha512-psb6xjLj47+fE76JdZwskvwG4MYsQKXUtMsPh6U0YMvmyjRtKRFcxnlXGWglNybtNTNVmGdp94K62/+NjF5FDQ==",
-      "dev": true,
       "requires": {
         "a-sync-waterfall": "^1.0.0",
         "asap": "^2.0.3",
@@ -1673,6 +1769,19 @@
       "dev": true,
       "requires": {
         "error-ex": "^1.2.0"
+      }
+    },
+    "parse5": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
+    },
+    "parse5-htmlparser2-tree-adapter": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
+      "integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
+      "requires": {
+        "parse5": "^6.0.1"
       }
     },
     "path-exists": {

--- a/package.json
+++ b/package.json
@@ -45,8 +45,10 @@
     "npm": ">= 6.14.8"
   },
   "dependencies": {
+    "cheerio": "^1.0.0-rc.5",
     "clean-css": "^5.0.1",
-    "markdown-it": "^12.0.2"
+    "markdown-it": "^12.0.2",
+    "nunjucks": "^3.2.3"
   },
   "devDependencies": {
     "chai": "^4.2.0",
@@ -57,7 +59,6 @@
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^5.0.0",
     "mocha": "^8.2.1",
-    "nunjucks": "^3.2.2",
     "sinon": "^9.2.1"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -54,6 +54,30 @@ The markdownify filter requires use of [Nunjuck's `safe` filter](https://mozilla
 
 Credit where credit is due, this idea was completely pinched from [Hugo's markdownify function](https://gohugo.io/functions/markdownify/).
 
+### `addattribute`
+
+Takes a string or a `markSafe` object, and adds an attribute or property to it.
+
+```javascript
+{{ 'This is some text' | addattribute('lang', 'en') }} // <span lang="en">This is some text</span>
+```
+
+Could also be set up to add a specific attribute - for example, `rel`:
+
+```javascript
+env.addFilter('addrel', (element, content) => addattribute({
+  element,
+  attribute: 'rel',
+  content,
+}))
+```
+
+could then be used
+
+```javascript
+{{ '<a href="https://example.com/next-article/">Next article</a>' | addrel('next') }} // <a href="https://example.com/next-article/" rel="next">Next article</a>
+```
+
 ## Set up
 
 Requires Node 14.x and npm 6.x.


### PR DESCRIPTION
This takes a string or a `markSafe` element and adds an attribute or property; for example:

```javascript
addattribute({
  element: nunjucks.runtime.markSafe('<a href="https://example.com">This is a link</a>'), 
  attribute: 'hreflang',
  content: 'en',
})
```

would return

```html
<a href="https://example.com" hreflang="en">This is a link</a>
```

Strings of text will be wrapped in a `span` element and returned as a `markSafe` element:

```js
addattribute({
  element: 'This is a string', 
  attribute: 'lang',
  content: 'en',
})
```

would return

```html
<span lang="en">This is a string</span>
```

This doesn't check to see if an attribute or property is allowed - so adding `attribute: 'blahblahblah'` would add that to the element.